### PR TITLE
Add installation of zstd package

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ print("Setting up non-interactive environment...")
 !echo "keyboard-configuration keyboard-configuration/variantcode string" | sudo debconf-set-selections
 
 print("Installing system dependencies...")
+!sudo DEBIAN_FRONTEND=noninteractive apt-get install zstd -y
 !curl -fsSL https://ollama.ai/install.sh | sudo sh
 !sudo apt-get update -y
 !sudo DEBIAN_FRONTEND=noninteractive apt-get install -y cuda-drivers ocl-icd-opencl-dev nvidia-cuda-toolkit


### PR DESCRIPTION
Added zstd package as ollama installation now requires it and kaggle does not have this package by default.